### PR TITLE
add: limit login points once per day

### DIFF
--- a/server/src/middlewares/pointsMiddleware.ts
+++ b/server/src/middlewares/pointsMiddleware.ts
@@ -22,20 +22,30 @@ export const updatePoints = asyncHandler(
     if (!user?.id || !activityType) {
       return next();
     }
+    const userRepository = AppDataSource.getRepository(User);
+    const userEntity = await userRepository.findOneBy({ id: user.id });
 
     const pointsToAdd = POINTS_CONFIG[activityType] ?? 0;
+
+    if (
+      activityType === "LOGIN" &&
+      userEntity?.lastLoginDate === userEntity?.lastLoginPoint
+    ) {
+      console.log("login points already given today");
+      return next();
+    }
+
     console.log(
       `User ID: ${user.id}, Activity: ${activityType}, Points to Add: ${pointsToAdd}`,
     );
 
-    if (pointsToAdd !== 0) {
+    if (pointsToAdd !== 0 && userEntity) {
+      if (activityType === "LOGIN") {
+        userEntity.lastLoginPoint = new Date();
+      }
+      userEntity.points += pointsToAdd;
       try {
-        const userRepository = AppDataSource.getRepository(User);
-        const userEntity = await userRepository.findOneBy({ id: user.id });
-        if (userEntity) {
-          userEntity.points += pointsToAdd;
-          await userRepository.save(userEntity);
-        }
+        await userRepository.save(userEntity);
       } catch (error) {
         console.error("Error updating user points:", error);
         return next(error);

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -33,6 +33,15 @@ export class User implements IUser {
   @Column("json", { nullable: true })
   subscription?: any;
 
+  @Column({ type: "date", nullable: true })
+  lastLoginDate!: Date | null;
+
+  @Column({ type: "date" })
+  registerDate!: Date;
+
+  @Column({ type: "date", nullable: true })
+  lastLoginPoint!: Date | null;
+
   @OneToMany(() => Medication, (medication) => medication.user, {
     cascade: ["insert", "update", "remove"],
   })

--- a/server/src/routers/authRoutes.ts
+++ b/server/src/routers/authRoutes.ts
@@ -53,6 +53,7 @@ router.post(
     }
 
     const user = userRepository.create({ email, password, fcmToken, username });
+    user.registerDate = new Date();
     await userRepository.save(user);
 
     req.user = user;
@@ -83,8 +84,10 @@ router.post(
 
     if (fcmToken) {
       user.fcmToken = fcmToken;
-      await userRepository.save(user);
     }
+
+    user.lastLoginDate = new Date();
+    await userRepository.save(user);
 
     req.user = user;
     req.body.token = signToken(user.id);


### PR DESCRIPTION
로그인시 지급 포인트 하루에 한번으로 제한
가입날짜, 최근로그인 db 저장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Implemented logic to prevent duplicate login points by checking and updating the user's last login date.
  - Added tracking for `registerDate` and `lastLoginDate` for new users.

- **Bug Fixes**
  - Ensured that users receive login points only once per login session.
  - Updated user properties to properly save registration and last login dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->